### PR TITLE
Results API Proposal

### DIFF
--- a/app/Http/Controllers/RaceController.php
+++ b/app/Http/Controllers/RaceController.php
@@ -27,6 +27,22 @@ class RaceController extends Controller
         return view('race.results', ['id' => $id, 'drivers' => $drivers, 'race' => $race]);
     }
 
+    public function resultsAPI($id) {
+        $race = Race::where('session_id', $id)->with('drivers.votes')->first();
+        $dbDrivers = $race->drivers()->get();
+        $totalVotes = $race->getTotalVotes();
+
+        $retDriversA = [];
+        $dbDrivers->each(function ($driver) use (&$retDriversA, &$totalVotes, &$race) {
+            array_push($retDriversA, [
+                'name' => $driver->name,
+                'votes' => ($totalVotes > 0) ? $driver->getDriverVotes($race->id) / $totalVotes : -1
+            ]);
+        });
+
+        return ['data' => ['drivers' => $retDriversA, 'subsession' => $id]];
+    }
+
     public function links($id) {
         $QRurl = url('/race/vote/' . $id);
         $url = url('/race/qr/'. $id);

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,8 @@ Route::get('race/links/{id}', '\App\Http\Controllers\RaceController@links');
 Route::get('race/qr/{id}', '\App\Http\Controllers\RaceController@showQR');
 Route::get('race/dotd/{id}', '\App\Http\Controllers\RaceController@showDOTD');
 
+Route::get('raceapi/{id}/results', '\App\Http\Controllers\RaceController@resultsAPI');
+
 Route::middleware([
     'auth:sanctum',
     config('jetstream.auth_session'),


### PR DESCRIPTION
I was wondering if you'd be willing to expose some of your voting results via a JSON API.  I was thinking it would be interesting to include some of that info when generating the text for things like https://arturo-mayorga.github.io/irl_stats/dist/?m=results&league=4534&season=105035&subsession=68522278&simsession=0 and https://www.youtube.com/watch?v=sh8QhkxaXPw

I plan to call into something like this about once per subsession as I generate the narrative text.

What do you think?

P.S. I don't have my system set up to run PHP but I'm 90% this should work.  If you'd like me to test it or add unit tests, I'm happy to do so but I might need some documentation on how to set that up with the correct DBs and all that Jazz. 