### PR TITLE
Adding error checking to RaceController::resultsAPI()

### DIFF
--- a/app/Http/Controllers/RaceController.php
+++ b/app/Http/Controllers/RaceController.php
@@ -52,7 +52,7 @@ class RaceController extends Controller
         return view('race.dotd', ['drivers' => $top3col, 'totalVotes' => $totalVotes, 'race' => $race, 'id' => $id]);
     }
 
-    function resultsAPI($id) {
+    public function resultsAPI($id) {
         $retDriversA = [];
 
         $race = Race::where('session_id', $id)->with('drivers.votes')->first();

--- a/app/Http/Controllers/RaceController.php
+++ b/app/Http/Controllers/RaceController.php
@@ -52,20 +52,25 @@ class RaceController extends Controller
         return view('race.dotd', ['drivers' => $top3col, 'totalVotes' => $totalVotes, 'race' => $race, 'id' => $id]);
     }
 
-    public function resultsAPI($id) {
-        $race = Race::where('session_id', $id)->with('drivers.votes')->first();
-        $dbDrivers = $race->drivers()->get();
-        $totalVotes = $race->getTotalVotes();
-
+    function resultsAPI($id) {
         $retDriversA = [];
-        $dbDrivers->each(function ($driver) use (&$retDriversA, &$totalVotes, &$race) {
-            $driverVotes = $driver->getDriverVotes($race->id);
-            array_push($retDriversA, [
-                'name' => $driver->name,
-                'percentage' => ($totalVotes > 0) ? $driverVotes / $totalVotes : -1,
-                'votes' => ($totalVotes > 0) ? $driverVotes : -1
-            ]);
-        });
+
+        $race = Race::where('session_id', $id)->with('drivers.votes')->first();
+
+        if ($race) {
+            $dbDrivers = $race->drivers()->get();
+            $totalVotes = $race->getTotalVotes();
+
+
+            $dbDrivers->each(function ($driver) use (&$retDriversA, &$totalVotes, &$race) {
+                $driverVotes = $driver->getDriverVotes($race->id);
+                array_push($retDriversA, [
+                    'name' => $driver->name,
+                    'percentage' => ($totalVotes > 0) ? $driverVotes / $totalVotes : -1,
+                    'votes' => ($totalVotes > 0) ? $driverVotes : -1
+                ]);
+            });
+        }
 
         return ['data' => ['drivers' => $retDriversA, 'subsession' => $id]];
     }


### PR DESCRIPTION
It would be nice to have a way to handle situations where a particular subsession does not have any votes.  For example, a request to https://driverofthe.day/api/123/results ends up returning a php callstack. With this change, we would return an empty list for situations where there are no available results.